### PR TITLE
Ignore vscode settings.json

### DIFF
--- a/.config/git/ignore
+++ b/.config/git/ignore
@@ -50,7 +50,6 @@ Temporary Items
 ## Visual Studio Code ##
 
 .vscode/*
-!.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json


### PR DESCRIPTION
settings.json can sometimes contain user-specific paths.